### PR TITLE
FIX - getWalkTheChatAttributeValue() must implement interface \ProductInterface

### DIFF
--- a/Observer/SalesOrderCreditmemoRefund.php
+++ b/Observer/SalesOrderCreditmemoRefund.php
@@ -87,33 +87,35 @@ class SalesOrderCreditmemoRefund implements \Magento\Framework\Event\ObserverInt
 
             foreach ($order->getAllItems() as $item) {
                 $product       = $item->getProduct();
-                $walkTheChatId = $this->helper->getWalkTheChatAttributeValue($product);
+                if ($product) {
+                    $walkTheChatId = $this->helper->getWalkTheChatAttributeValue($product);
 
-                if (!$walkTheChatId) {
-                    $parentIds = $this->configurableProductType->getParentIdsByChild($product->getId());
+                    if (!$walkTheChatId) {
+                        $parentIds = $this->configurableProductType->getParentIdsByChild($product->getId());
 
-                    if (count($parentIds)) {
-                        $product = $this->productRepository->getById($parentIds[0]);
-                        $walkTheChatId = $this->helper->getWalkTheChatAttributeValue($product);
+                        if (count($parentIds)) {
+                            $product = $this->productRepository->getById($parentIds[0]);
+                            $walkTheChatId = $this->helper->getWalkTheChatAttributeValue($product);
+                        }
                     }
-                }
 
-                if (
-                    $walkTheChatId
-                    && !$this->queueService->isDuplicate(
-                        $product->getId(),
-                        \Walkthechat\Walkthechat\Model\Action\Update::ACTION,
-                        'product_id'
-                    )
-                ) {
-                    /** @var \Walkthechat\Walkthechat\Api\Data\QueueInterface $model */
-                    $model = $this->queueFactory->create();
+                    if (
+                        $walkTheChatId
+                        && !$this->queueService->isDuplicate(
+                            $product->getId(),
+                            \Walkthechat\Walkthechat\Model\Action\Update::ACTION,
+                            'product_id'
+                        )
+                    ) {
+                        /** @var \Walkthechat\Walkthechat\Api\Data\QueueInterface $model */
+                        $model = $this->queueFactory->create();
 
-                    $model->setProductId($product->getId());
-                    $model->setWalkthechatId($walkTheChatId);
-                    $model->setAction(\Walkthechat\Walkthechat\Model\Action\Update::ACTION);
+                        $model->setProductId($product->getId());
+                        $model->setWalkthechatId($walkTheChatId);
+                        $model->setAction(\Walkthechat\Walkthechat\Model\Action\Update::ACTION);
 
-                    $this->queueRepository->save($model);
+                        $this->queueRepository->save($model);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Description:  

We have an error in the Rouje website. The RMA generating the creditmemo with an online refund are blocked. The reason is that there is fatal error. Please see below the trace.

PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Walkthechat\Walkthechat\Helper\Data::getWalkTheChatAttributeValue() must implement interface Magento\Catalog\Api\Data\ProductInterface, null given, called in /home/rouje/www/vendor/walkthechat/magento2-plugin-v2/Observer/SalesOrderCreditmemoRefund.php on line 90 and defined in /home/rouje/www/vendor/walkthechat/magento2-plugin-v2/Helper/Data.php:381
Stack trace:
#0 /home/rouje/www/vendor/walkthechat/magento2-plugin-v2/Observer/SalesOrderCreditmemoRefund.php(90): Walkthechat\Walkthechat\Helper\Data->getWalkTheChatAttributeValue()
#1 /home/rouje/www/vendor/magento/framework/Event/Invoker/InvokerDefault.php(88): Walkthechat\Walkthechat\Observer\SalesOrderCreditmemoRefund->execute()
#2 /home/rouje/www/vendor/magento/framework/Event/Invoker/InvokerDefault.php(74): Magento\Framework\Event\Invoker\InvokerDefault->_callObserverMethod()
#3 /home/rouje/www/generated/code/Magento/Framework/Event/Invoker/InvokerDefault/Interceptor.php(23): Magento\Framework\Event\Invoker\InvokerDe in /home/rouje/www/vendor/walkthechat/magento2-plugin-v2/Helper/Data.php on line 381